### PR TITLE
unify syntax in readmes

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -81,9 +81,9 @@ Method section definition. This macro available only in `index.md` file.
 ## How to use anabelle
 
 ```bash
-~ $ cd myApi
-~/myApi $ composer require contributte/anabelle
-~/myApi $ vendor/bin/anabelle docs-src docs
+cd myApi
+composer require contributte/anabelle
+vendor/bin/anabelle docs-src docs
 ```
 
 ### CLI options


### PR DESCRIPTION
Polished docs
- use 4 spaces in CSS, in JS, in HTML and in Latte
- use tab in NEON and in PHP
- neon highlighting syntax
- normalized filename of Readmes
- typos